### PR TITLE
fix: Remove GitHub button click action

### DIFF
--- a/desktop_app/src/main_window.py
+++ b/desktop_app/src/main_window.py
@@ -43,7 +43,7 @@ class MainWindow(QMainWindow):
         self.github_button = QPushButton("GitHub")
         self.github_button.setFixedWidth(80)
         top_section_layout.addWidget(self.github_button)
-        self.github_button.clicked.connect(self.on_github_button_clicked)
+        # self.github_button.clicked.connect(self.on_github_button_clicked) # Connection removed
 
         self.folder_button = QPushButton("Folder")
         self.folder_button.setFixedWidth(80)
@@ -170,8 +170,8 @@ class MainWindow(QMainWindow):
 
         self.apply_stylesheet() # Apply custom stylesheet
 
-    def on_github_button_clicked(self):
-        self.path_input_field.setText("https://github.com/Juqika/repomix-app.git")
+    # def on_github_button_clicked(self): # Method removed
+    #     self.path_input_field.setText("https://github.com/Juqika/repomix-app.git")
 
     def on_folder_button_clicked(self):
         directory = QFileDialog.getExistingDirectory(self, "Select Folder")


### PR DESCRIPTION
Removes the functionality previously associated with the 'GitHub' button in the top input section. The `on_github_button_clicked` method, which set the input field to a predefined URL, has been deleted. The corresponding signal connection for the button's clicked event has also been removed.

The 'GitHub' button now serves as a static UI element without a specific click action.

<!-- Please include a summary of the changes -->

## Checklist

- [ ] Run `npm run test`
- [ ] Run `npm run lint`
